### PR TITLE
Specify SSL protocol for useSSL=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ rabbitClient.connect( host='localhost', port=5672, username='guest', password='g
 Or, for SSL-enabled connections:
 
 ```js
-rabbitClient.connect( host='localhost', port=5672, username='guest', password='guest', virtualHost='/', useSSL = true, sslProtocol = 'TLSV1.2');
+rabbitClient.connect( host='localhost', port=5671, username='guest', password='guest', virtualHost='/', useSSL = true, sslProtocol = 'TLSV1.2');
 ```
 
 In ColdBox, the RabbitClient will register a `prereinit` interceptor listener to shut itself down when the framework reinits.  If you have another scenario such as a test case suite that simply clears the application scope 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ moduleSettings = {
 		username : getSystemSetting( 'rabbit_username' ),
 		password : getSystemSetting( 'rabbit_password' ),
 		virtualHost : getSystemSetting( 'rabbit_virtualHost' ),
-		useSSL : getSystemSetting( 'rabbit_useSSL' )
+		useSSL : getSystemSetting( 'rabbit_useSSL' ),
+		sslProtocol : getSystemSetting( 'rabbit_sslProtocol' )
 	}
 };
 ```
@@ -100,8 +101,14 @@ moduleSettings = {
 You can also manually create your connection, which only needs to happen once:
 
 ```js
-rabbitClient.connect( host='localhost', port=5672, username='guest', password='guest', virtualHost='/', useSSL=true );
+rabbitClient.connect( host='localhost', port=5672, username='guest', password='guest', virtualHost='/');
 ```   
+
+Or, for SSL-enabled connections:
+
+```js
+rabbitClient.connect( host='localhost', port=5672, username='guest', password='guest', virtualHost='/', useSSL = true, sslProtocol = 'TLSV1.2');
+```
 
 In ColdBox, the RabbitClient will register a `prereinit` interceptor listener to shut itself down when the framework reinits.  If you have another scenario such as a test case suite that simply clears the application scope 
 when it's finished, it will leave hanging connections which you can see in the web-based management UI.

--- a/models/RabbitClient.cfc
+++ b/models/RabbitClient.cfc
@@ -50,7 +50,7 @@ component accessors=true singleton ThreadSafe {
 	 * connection details have been provided in the module settings.
 	 * This RabbitClient wraps a single, persisted conenction to RabbitMQ.
 	 */
-	function connect( string host, string port, string username, string password, string virtualHost, boolean useSSL, boolean quiet=false ){
+	function connect( string host, string port, string username, string password, string virtualHost, boolean useSSL, boolean quiet=false, string sslProtocol = 'TLSV1.2' ){
 		
 		if( hasConnection() ) {
 			if( quiet ) {
@@ -88,7 +88,7 @@ component accessors=true singleton ThreadSafe {
 			factory.setPassword( thisPassword );
 			
 			if( isBoolean( thisUseSSL ) ) {
-				factory.useSslProtocol( thisUseSSL );	
+				factory.useSslProtocol( arguments.sslProtocol );	
 			}
 			
 			if( len( thisVirtualHost ) ) {


### PR DESCRIPTION
SSL-enabled connections would throw `SSLContext not available - java.security.NoSuchAlgorithmException` on the line:

`factory.useSSLProtocol( thisUseSSL );`

(`thisUseSSL` === `true`)

From glancing at the javadocs, it looks like it wanted the actual protocol to use there. `'TLSV1.2'` worked when we tried it for our SSL-enabled RabbitMQ server, so I put that in as a default but allowed it to be overridden.

Updated the README with that example and also adjusted the port to `5671` which is the default AMQP SSL listener.