### PR TITLE
BOX-125 Fix issue with tests failing with "Unsupported or unrecognized SSL message"

### DIFF
--- a/models/RabbitClient.cfc
+++ b/models/RabbitClient.cfc
@@ -89,7 +89,7 @@ component accessors=true singleton ThreadSafe {
 			factory.setUsername( thisUsername );
 			factory.setPassword( thisPassword );
 			
-			if( isBoolean( thisUseSSL ) ) {
+			if( isBoolean( thisUseSSL ) && thisUseSSL ) {
 				factory.useSslProtocol( arguments.sslProtocol );	
 			}
 			


### PR DESCRIPTION
The SDK is always setting the TLS protocol when 'useSSL' is _boolean_. So if you explicitly set it to `false` then it still tries to use it.

This simple change ensures it is set to `true`.