### PR TITLE
BOX-126 provide sensible defaults for the rabbitmq host config

### DIFF
--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -67,11 +67,11 @@
 
 		moduleSettings = {
 			rabbitsdk = {
-				host : getSystemSetting( 'rabbit_host' ),
-				username : getSystemSetting( 'rabbit_username' ),
-				password : getSystemSetting( 'rabbit_password' ),
-				virtualHost : getSystemSetting( 'rabbit_virtualHost' ),
-				useSSL : getSystemSetting( 'rabbit_useSSL' )
+				host : getSystemSetting( 'rabbit_host', 'localhost' ),
+				username : getSystemSetting( 'rabbit_username', 'guest' ),
+				password : getSystemSetting( 'rabbit_password', 'guest' ),
+				virtualHost : getSystemSetting( 'rabbit_virtualHost', '/' ),
+				useSSL : getSystemSetting( 'rabbit_useSSL', '' )
 			}
 		};
 


### PR DESCRIPTION
Make it one step easier to run tests locally by providing sensible defaults for environment settings: https://ortussolutions.atlassian.net/browse/BOX-126