### PR TITLE
BOX-127 make portable for lucee

### DIFF
--- a/models/Channel.cfc
+++ b/models/Channel.cfc
@@ -8,6 +8,7 @@ component accessors="true"  {
 	// DI
 //	property name="javaloader" inject="loader@cbjavaloader";
 	property name="wirebox" inject="wirebox";
+	property name="rabbitJavaLoader" inject="rabbitJavaLoader@RabbitSDK";
 		
 	/** The RabbitMQ Connection this channel belongs to */
 	property name="connection" type="any";
@@ -25,8 +26,8 @@ component accessors="true"  {
 		setConsumerTag( '' );
 		setChannel( getConnection().createChannel() );
 		//setMessagePropertiesBuilder( javaloader.create( "com.rabbitmq.client.AMQP$BasicProperties$Builder" ) );
-		setMessagePropertiesBuilder( createObject( "java", "com.rabbitmq.client.AMQP$BasicProperties$Builder" ) );
-		setJavaExchangeType( createObject( "java", "com.rabbitmq.client.BuiltinExchangeType" ) );
+		setMessagePropertiesBuilder( rabbitJavaLoader.create( "com.rabbitmq.client.AMQP$BasicProperties$Builder" ) );
+		setJavaExchangeType( rabbitJavaLoader.create( "com.rabbitmq.client.BuiltinExchangeType" ) );
 		setJavaUtilDate( createObject( 'java', 'java.util.Date' ) );
 		return this;
 	}
@@ -386,18 +387,12 @@ component accessors="true"  {
 		}
 		
 		
-		var consumerProxy = createDynamicProxy(
-			wirebox.getInstance( name='consumer@rabbitsdk', initArguments={
-				 	channel : this,
-				 	consumer : consumer,
-				 	error : error,
-				 	component : component,
-				 	autoAcknowledge : autoAcknowledge
-				 } ),
-			//[ javaloader.create( "com.rabbitmq.client.Consumer" ) ]
-			// Adobe doesn't support this
-			//[ createObject( "java", "com.rabbitmq.client.Consumer" ) ]
-			[ "com.rabbitmq.client.Consumer" ]
+		var consumerProxy = rabbitJavaLoader.getConsumerProxy(
+			channel=this,
+			consumer=consumer,
+			error=error,
+			component=component,
+			autoAcknowledge=autoAcknowledge
 		);
 		
 		getChannel().basicQos( prefetch );

--- a/models/RPCClient.cfc
+++ b/models/RPCClient.cfc
@@ -19,6 +19,7 @@ component accessors="false"  {
 	property name="routingKey" type="string" default="RPC_Queue";
 	property name="timeout" type="numeric" default="15";
 	property name="RPCClientHash" type="string";
+	property name="rabbitJavaLoader" inject="rabbitJavaLoader@RabbitSDK";
 	
 	/**
 	 * configure a new Client
@@ -45,8 +46,8 @@ component accessors="false"  {
 		variables.channel = rabbitClient.createChannel();
 		
 		// Create a new instance of the java RPC Client class using a RPCClientParams instance to configure it.
-		variables.jRPCCLient = createObject( 'java', 'com.rabbitmq.client.RpcClient' ).init(
-			createObject( 'java', 'com.rabbitmq.client.RpcClientParams' )
+		variables.jRPCCLient = rabbitJavaLoader.create( 'com.rabbitmq.client.RpcClient' ).init(
+			rabbitJavaLoader.create( 'com.rabbitmq.client.RpcClientParams' )
 				.channel( channel.getChannel() )
 				.exchange( arguments.exchange )
 				.routingKey( arguments.routingKey )

--- a/models/RabbitClient.cfc
+++ b/models/RabbitClient.cfc
@@ -16,6 +16,7 @@ component accessors=true singleton ThreadSafe {
 	property name="interceptorService" inject="box:InterceptorService";
 //	property name="javaloader" inject="loader@cbjavaloader";
 	property name="log" inject="logbox:logger:{this}";
+	property name="rabbitJavaLoader" inject="rabbitJavaLoader@RabbitSDK";
 	property name="RPCClients" type="struct";
 	
 
@@ -84,7 +85,7 @@ component accessors=true singleton ThreadSafe {
 			log.debug( 'Creating connection to [#thisHost#]' );
 			
 			//var factory = javaloader.create( "com.rabbitmq.client.ConnectionFactory" ).init();
-			var factory = createObject( "java", "com.rabbitmq.client.ConnectionFactory" ).init();
+			var factory = rabbitJavaLoader.create( "com.rabbitmq.client.ConnectionFactory" ).init();
 			factory.setHost( thisHost );
 			factory.setUsername( thisUsername );
 			factory.setPassword( thisPassword );

--- a/models/RabbitClient.cfc
+++ b/models/RabbitClient.cfc
@@ -89,7 +89,7 @@ component accessors=true singleton ThreadSafe {
 			factory.setUsername( thisUsername );
 			factory.setPassword( thisPassword );
 			
-			if( isBoolean( thisUseSSL ) ) {
+			if( isBoolean( thisUseSSL ) && thisUseSSL ) {
 				factory.useSslProtocol( arguments.sslProtocol );	
 			}
 			

--- a/models/RabbitJavaLoader.cfc
+++ b/models/RabbitJavaLoader.cfc
@@ -1,0 +1,40 @@
+/**
+ * Utility component to help loading java classes from
+ * RabbitMQ library
+ *
+ */
+component singleton ThreadSafe {
+
+	property name="wirebox" inject="wirebox";
+
+	public any function init() {
+		if ( isLucee() ) {
+			var libDir = ExpandPath( getDirectoryFromPath( getCurrentTemplatePath() ) & "../lib" );
+			variables.jars = DirectoryList( libDir, true, "path", "*.jar" );
+		}
+	}
+
+	public any function create( required string className ) {
+		if ( isLucee() ) {
+			return CreateObject( "java", arguments.className, variables.jars );
+		} else {
+			// TODO: use javaloader with ACF?
+			return CreateObject( "java", arguments.className );
+		}
+	}
+
+	public any function getConsumerProxy() {
+		var consumerInstance = wirebox.getInstance( name='consumer@rabbitsdk', initArguments=arguments );
+		if ( isLucee() ) {
+			return createDynamicProxy( consumerInstance, [ create( "com.rabbitmq.client.Consumer" ) ] );
+		} else {
+			// TODO: use javaloader with ACF?
+			return createDynamicProxy( consumerInstance, [ "com.rabbitmq.client.Consumer" ] );
+		}
+	}
+
+	private boolean function isLucee() {
+		return StructKeyExists( server, "lucee" );
+	}
+
+}

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -67,11 +67,11 @@
 
 		moduleSettings = {
 			rabbitsdk = {
-				host : getSystemSetting( 'rabbit_host' ),
-				username : getSystemSetting( 'rabbit_username' ),
-				password : getSystemSetting( 'rabbit_password' ),
-				virtualHost : getSystemSetting( 'rabbit_virtualHost' ),
-				useSSL : getSystemSetting( 'rabbit_useSSL' )
+				host : getSystemSetting( 'rabbit_host', 'localhost' ),
+				username : getSystemSetting( 'rabbit_username', 'guest' ),
+				password : getSystemSetting( 'rabbit_password', 'guest' ),
+				virtualHost : getSystemSetting( 'rabbit_virtualHost', '/' ),
+				useSSL : getSystemSetting( 'rabbit_useSSL', '' )
 			}
 		};
 

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -30,11 +30,13 @@ component{
 	this.mappings[ "/moduleroot" ] = moduleRootPath;
 	this.mappings[ "/#request.MODULE_NAME#" ] = moduleRootPath & "#request.MODULE_NAME#";
 	
-	this.javaSettings = {
-		loadPaths = directorylist( moduleRootPath & '#request.MODULE_NAME#/lib', true, 'array', '*jar' ),
-		loadColdFusionClassPath = true,
-		reloadOnChange = false
-	};
+	if ( !structKeyExists( server, "lucee" ) ) {
+		this.javaSettings = {
+			loadPaths = directorylist( moduleRootPath & '#request.MODULE_NAME#/lib', true, 'array', '*jar' ),
+			loadColdFusionClassPath = true,
+			reloadOnChange = false
+		};
+	}
 
 	function onRequestEnd() {
 		structClear( application );


### PR DESCRIPTION
Use `CreateObject( "java", className, jarPaths )` in Lucee to dynamically pull in the library rather than relying on developers to have an additional manual step of adding to global jar lib in Application.cfc. Allowing it to be portable.

Perhaps this simple approach could also be used to use javaloader only for ACF?