### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Transient that represents a message received from the server for you to process.
 * **getHeaders()** - Struct containing any custom headers
 * **getMessageId()** - Message ID
 * **getPriority()** - Priority (numeric, 1-10)
+* **getRawBody()** - The raw body of the message.
 * **getReplyTo()** - Reply to
 * **getTimestamp()** - Timestamp (java.util.Date)
 * **getType()** - Type


### PR DESCRIPTION
Mention the getRawBody() getter in the README file.

We encountered an encoding issue with serialized JSON objects when fetching them via getBody(). Using getRawBody() instead fixed this for us, hence the proposal to add it to the README.